### PR TITLE
Refactor configuration handling and remove unused Docker check

### DIFF
--- a/AspireApp.AppHost/AppHost.cs
+++ b/AspireApp.AppHost/AppHost.cs
@@ -6,25 +6,31 @@ using System.Diagnostics;
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Check if Docker is running  (See if we can somehow move the function to Extensions later)
-CheckDockerIsRunning();
+// FRITZ: Removed as it is now part of .NET Aspire
+
+// FRITZ: Config with .NET Aspire
+var aiModel = builder.AddParameterFromConfiguration("AI_Model", "AI_Model");
+var aiEndpoint = builder.AddParameterFromConfiguration("AI_Endpoint", "AI_Endpoint");
+
+
 
 // Read Configs - setup details to pass through.
 // (Not sure of the best way to accomplish this)
 // CONFIGURATIONS  
-var environmentName = builder.Environment.EnvironmentName;
-var baseProjectDirectory = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..");
-Console.WriteLine($"Base project directory: {baseProjectDirectory}");
-var blazorProjectPath = Path.Combine(baseProjectDirectory, "AspireApp.Web");
-var baseSettingsPath = Path.Combine(blazorProjectPath, "appsettings.json");
-var envSettingsPath = Path.Combine(blazorProjectPath, $"appsettings.{environmentName}.json");
-var configuration = new ConfigurationBuilder()
-	.SetBasePath(Directory.GetCurrentDirectory())
-	.AddJsonFile(baseSettingsPath, optional: false)
-	.AddJsonFile(envSettingsPath, optional: true)
-	.Build();
-// Fetch and set values for ollama endpoint & model
-var aiModel = configuration.GetValue<string>("AI_Model") ?? "phi3:latest";
-var aiEndpoint = configuration.GetValue<string>("AI_Endpoint") ?? "http://localhost:11434";
+// var environmentName = builder.Environment.EnvironmentName;
+// var baseProjectDirectory = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..");
+// Console.WriteLine($"Base project directory: {baseProjectDirectory}");
+// var blazorProjectPath = Path.Combine(baseProjectDirectory, "AspireApp.Web");
+// var baseSettingsPath = Path.Combine(blazorProjectPath, "appsettings.json");
+// var envSettingsPath = Path.Combine(blazorProjectPath, $"appsettings.{environmentName}.json");
+// var configuration = new ConfigurationBuilder()
+// 	.SetBasePath(Directory.GetCurrentDirectory())
+// 	.AddJsonFile(baseSettingsPath, optional: false)
+// 	.AddJsonFile(envSettingsPath, optional: true)
+// 	.Build();
+// // Fetch and set values for ollama endpoint & model
+// var aiModel = configuration.GetValue<string>("AI_Model") ?? "phi3:latest";
+// var aiEndpoint = configuration.GetValue<string>("AI_Endpoint") ?? "http://localhost:11434";
 
 // API Service
 var apiService = builder.AddProject<Projects.AspireApp_ApiService>("apiservice")
@@ -36,7 +42,7 @@ var ollama = builder.AddOllama("ollama")
 	.WithAnnotation(new ContainerImageAnnotation { Image = "ollama/ollama", Tag = "0.9.5" })
 	.WithDataVolume()
 	.WithContainerRuntimeArgs("--gpus", "all");
-var appmodel = ollama.AddModel("chat", aiModel);
+var appmodel = ollama.AddModel("chat", aiModel.Resource.Value);
 
 // BLAZOR app (TODO add references and Chat function later)
 // See Blazor Home page... and the variables I pull...
@@ -53,15 +59,3 @@ builder.AddProject<Projects.AspireApp_Web>("webfrontend")
 	.WaitFor(apiService);
 
 await builder.Build().RunAsync();
-
-// Support function for later moving to Extensions
-static void CheckDockerIsRunning()
-{
-	var dockerProcesses = Process.GetProcessesByName("com.docker.backend");
-	if (dockerProcesses.Length <= 0)
-	{
-		Console.WriteLine("Docker does not appear to be running!");
-		throw new InvalidOperationException("Docker is not running. Please start Docker and try again.");
-	}
-	Console.WriteLine("Docker is running!");
-}

--- a/AspireApp.AppHost/AspireApp.AppHost.csproj
+++ b/AspireApp.AppHost/AspireApp.AppHost.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AspireApp.ApiService\AspireApp.ApiService.csproj" />
-    <ProjectReference Include="..\AspireApp.ServiceDefaults\AspireApp.ServiceDefaults.csproj" />
     <ProjectReference Include="..\AspireApp.Web\AspireApp.Web.csproj" />
   </ItemGroup>
 

--- a/AspireApp.AppHost/appsettings.Development.json
+++ b/AspireApp.AppHost/appsettings.Development.json
@@ -4,5 +4,7 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+	"AI_Endpoint": "http://localhost:11434/",
+	"AI_Model": "phi4-mini:latest"
 }

--- a/AspireApp.AppHost/appsettings.json
+++ b/AspireApp.AppHost/appsettings.json
@@ -5,5 +5,7 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
-  }
+  },
+	"AI_Endpoint": "http://localhost:11434/",
+	"AI_Model": "llama3.2:latest"
 }

--- a/AspireApp.Web/appsettings.Development.json
+++ b/AspireApp.Web/appsettings.Development.json
@@ -5,6 +5,6 @@
 			"Microsoft.AspNetCore": "Warning"
 		}
 	},
-	"AI_Endpoint": "http://localhost:11434/",
-	"AI_Model": "phi4-mini:latest"
+	"AI_Endpoint": "",
+	"AI_Model": ""
 }

--- a/AspireApp.Web/appsettings.json
+++ b/AspireApp.Web/appsettings.json
@@ -6,6 +6,6 @@
 		}
 	},
 	"AllowedHosts": "*",
-	"AI_Endpoint": "http://localhost:11434/",
-	"AI_Model": "llama3.2:latest"
+	"AI_Endpoint": "",
+	"AI_Model": ""
 }

--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ dotnet --version
 ```
 - **Aspire Tooling**: [Setup instructions](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?tabs=windows&pivots=vscode) Install tools from commandline
 
-```
-dotnet workload install aspire
-```
-
 Once prerequisites are installed, you can perform an initial build:
 ```
 dotnet build


### PR DESCRIPTION
Removed Docker check because .NET Aspire 9.3 and later have that feature and will manage Docker interactions at startup for you

Added sample configuration in AppHost/AppSettings.json to show how to pass config values to child projects.  Note: by default environment variables, like from Aspire, take precedence over appsettings  values