### PR TITLE
P1 Python Services Pipeline Stabilization

### DIFF
--- a/.squad/agents/bob/history.md
+++ b/.squad/agents/bob/history.md
@@ -244,3 +244,22 @@
 - Fixture: `src/AspireApp.WebTest/Fixtures/TestFixture.cs`
 - Model: `src/AspireApp.WebTest/DataModels/AppHostMappingModel.cs`
 
+
+### 2026-03-25 — Roadmap Maintenance & Challenge Tracking
+
+**Scope:** User directive — keep oadmap/Tasks.md updated as work progresses; track emerging implementation challenges.
+
+**Work Completed:**
+- Added maintainer reminder blockquote at top of Tasks.md (enforces active status updates)
+- Created "Implementation Challenges & Revisit Items" section:
+  - Infrastructure risks: Volume mount validation (Gate B may fail silently)
+  - Architectural unknowns: LightRAG integration surface clarity
+  - Technical debt signals: Weak env-var testing, sparse test coverage
+  - Performance: Neo4j batch write profiling not yet done
+
+**Decision Generated:**
+- **Roadmap Status Tracking & Challenge Log** — Process rule: roadmap edits happen during/immediately after task completion, not retroactively
+
+**Impact:** Roadmap is now a living document with embedded discipline. Challenges surface early for cross-team visibility. Foundation for next iteration planning.
+
+**Related:** Decision merged to .squad/decisions.md. Orchestration log at .squad/orchestration-log/2026-03-25T14-09-00Z-bob.md. Session log at .squad/log/2026-03-25T14-09-00Z-roadmap-maintenance.md.

--- a/.squad/agents/buster/history.md
+++ b/.squad/agents/buster/history.md
@@ -212,3 +212,10 @@
 
 **Decision Logged:** "Aspire Dashboard Playwright Tests Must Wait for Auth Redirect" in `.squad/decisions.md` for team adoption.
 
+### 2026-03-25 — P1 Processing Pipeline Regression Gate
+
+- **Focused regression coverage exists now.** Added `src/AspireApp.PythonServices/tests/test_processing_pipeline_regression.py` with dependency-free `unittest` coverage for the processing lifecycle plus direct `process_document_task()` orchestration.
+- **Retry behavior is part of the QA contract.** Failed `files` rows must remain eligible for `list_unprocessed_documents()`, and a transition back to `processing` must clear stale completion/error fields before a rerun can be treated as clean.
+- **Validation gate for this area:** `python -m unittest discover -s src\AspireApp.PythonServices\tests -p "test_*.py" -v` plus `python test_database_schema.py` both pass on the current working tree.
+- **Reusable test pattern:** when workstation Python lacks FastAPI/Pydantic, stub those modules via `sys.modules`, purge cached `app.*` modules between imports, and keep SQLite scratch data under a repo-local test folder instead of OS temp paths.
+

--- a/.squad/agents/jarvis/history.md
+++ b/.squad/agents/jarvis/history.md
@@ -228,3 +228,16 @@
 
 **Next Phase:** Jeff owns canonical Python contract surface maintenance. Validation gates remain live.
 
+### 2026-03-25 — P1 Processing Pipeline Stabilization
+
+**Completed:**
+- Stabilized retries by clearing stale docling/Neo4j result fields and existing `document_pages` rows whenever a file re-enters `processing`.
+- Kept batch selection aligned with the canonical lifecycle by allowing both `uploaded` and `error` rows back into the processing queue.
+- Hardened the processing router so duplicate starts are rejected while a file is already in `processing`.
+
+**Validation:**
+- `python -m compileall src\\AspireApp.PythonServices\\app`
+- `python src\\AspireApp.PythonServices\\tests\\test_p0_contract_audit.py`
+
+**Key insight:** Retry safety in the canonical `files` + `document_pages` schema depends on resetting derived artifacts at the start of a new attempt. Otherwise the `(file_id, page_number)` uniqueness rule turns partial failures into duplicate-write failures on retry.
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,494 +2,11 @@
 
 > Shared decision log. All agents read this before starting work.
 > Scribe merges new decisions from `.squad/decisions/inbox/` after each session.
-> **Note (2026-03-21):** Merged 4 inbox decisions (jeff-aspire-dashboard-test-auth.md, buster-aspire-dashboard-test-audit.md, buster-aspire-dashboard-auth-re-review.md, bob-dashboard-test-redirect-settle.md). File size 28.2 KB. All entries ≤30 days old. Inbox cleared.
+> **Note (2026-03-25):** Archived pre-2026-02-27 entries (6 decisions, ~12 KB) to `decisions-archive.md` due to file size (30.75 KB → 18.5 KB target). Merged 2 inbox decisions: bob-roadmap-tracking-2026-03-25.md, copilot-directive-2026-03-25T14-07-58Z.md. Inbox cleared.
 
 
 <!-- Decisions are appended below. Each entry starts with ### -->
 
-## Architecture Review — Bob (Lead/Architect) — 2026-02-21
-
-**Scope:** Comprehensive architecture review of AspireAI solution
-
-### CRITICAL: Python Router↔DatabaseService Contract Misalignment
-
-Python Pydantic models and routers are out of sync with the DatabaseService class. The routers call ~10 methods (`get_document()`, `get_unprocessed_documents()`, `get_processed_document()`, `save_processed_document()`, etc.) that **do not exist** on the current DatabaseService. This causes `AttributeError` at runtime on most document and processing endpoints.
-
-**Decision:** Either add the missing wrapper methods to DatabaseService or rewrite routers to call the current API (`get_file_by_id()`, `get_unprocessed_files()`, `get_all_files()`). Option (b) is cleaner.
-
-**Impact:** Processing pipeline (Gate B1/B2) is completely blocked until fixed. ~1 day effort.
-
-### HIGH: Status Casing Mismatch
-
-FileUploadController.cs line 123 writes `"Uploaded"` (capital U) to the status field, but Python's `get_unprocessed_files()` queries `WHERE status = 'uploaded'` (lowercase). **Files uploaded via the C# Web UI will never be found by Python for processing.**
-
-**Decision:** Normalize to lowercase `"uploaded"` in FileUploadController.cs. One-line fix unblocks entire pipeline.
-
-**Impact:** Fixes file discovery. ~30 minutes.
-
-### HIGH: ApiService is Vestigial
-
-AspireApp.ApiService contains only a weather forecast stub. The entire project is boilerplate with no integration into the document pipeline. Web frontend communicates directly with Python service and SQLite. ApiService adds startup latency and orchestration complexity for zero value.
-
-**Decision:** Three options: (a) keep as facade/proxy, (b) merge into Web, (c) remove entirely. Recommend (c) now. Add real API gateway later if needed.
-
-**Impact:** Simplifies startup, reduces orchestration bloat. Medium-term effort for removal.
-
-### MEDIUM: SQLite Concurrent Access Risk
-
-Two services (Web + Python) share one SQLite file via bind mount with dual access patterns: EF Core in C# and raw SQL in Python. SQLite with WAL mode handles this reasonably, but there's no coordination on schema migrations. Cold-start race condition possible.
-
-**Decision:** WaitFor(pythonServices) in AppHost mitigates. Add explicit schema version check at startup if needed. Monitor in production.
-
-**Impact:** Low immediate risk given WaitFor ordering. Document as potential issue.
-
-### MEDIUM: LightRAG Integration is Wired But Unverified
-
-LightRAG container is registered with full configuration in AppHost but has no health check or integration test. Web frontend `WaitFor(lightrag)` blocks on it. No Python or C# code references LightRAG APIs.
-
-**Decision:** Either add `.WithHttpHealthCheck()` for LightRAG or remove `WaitFor(lightrag)` from webfrontend until integration code exists. Improves startup time during development.
-
-**Impact:** Fixes startup blocking. ~1 hour.
-
-### MEDIUM: global.json Targets .NET 10 Preview
-
-`global.json` specifies SDK 10.0.0 with `allowPrerelease: true`. All `.csproj` files target `net10.0`. This is fine for learning but creates dependency on preview SDK availability. README still references ".NET 9" (stale).
-
-**Decision:** Document .NET 10 requirement clearly in README. Consider pinning to stable SDK release when available.
-
-**Impact:** Maintenance task. Update docs immediately.
-
-### LOW: Legacy Entity Dead Weight
-
-`DocumentEntities.cs` carries deprecated `Document` and `ProcessedDocument` EF entities mapped to non-existent `documents` and `processed_documents` tables. These legacy tables are created by EF Core alongside the canonical `files` + `document_pages` tables, cluttering the schema.
-
-**Decision:** Remove deprecated entities and migrations after verifying no remaining code references them.
-
-**Impact:** Reduces confusion. ~2 hours effort.
-
-### LOW: No Automated Tests
-
-No test projects exist in the solution. `test_all_builds.py` and `test_database_schema.py` are utility scripts, not CI-ready test suites. Roadmap's "Testing Baseline" task is unstarted.
-
-**Decision:** Establish test infrastructure (CI build + test projects) before closing schema migration. Create C# xUnit project and Python pytest suite per Buster's recommendations.
-
-**Impact:** Enables safe refactoring. Foundation work required.
-
----
-
-## .NET Deep Analysis — Jeff (.NET Dev) — 2026-02-21
-
-**Scope:** .NET projects deep dive, build health, package dependency alignment
-
-### Config Key Mismatch: AI-Chat-Model vs AI-Model
-
-AppHost.cs line 129 passes `AI-Chat-Model` as environment variable, but Web project's `AiInfoStateService` and `HomeConfigurations` look for `AI-Model`. The model name may not propagate correctly through Aspire-injected env vars.
-
-**Decision:** Align environment variable naming. Update either AppHost to use `AI-Model` or Web services to check `AI-Chat-Model`. Prefer consistent naming across all Aspire services.
-
-**Impact:** Fixes AI model propagation. ~30 minutes.
-
-### LightRAG and Ollama Have No Health Checks
-
-LightRAG is registered with `AddContainer()` but has no `WithHttpHealthCheck()`. Ollama has no explicit health check configured. The webfrontend `WaitFor()` will wait indefinitely if either fails to start properly.
-
-**Decision:** Add `.WithHttpHealthCheck()` for both LightRAG (port 9621) and Ollama (port 11434). If health check endpoints don't exist, remove from WaitFor chain until integration code ready.
-
-**Impact:** Fixes startup blocking, improves debugging. ~1 hour.
-
-### SemanticKernel Version Mismatch
-
-`Microsoft.SemanticKernel` is at 1.71.0 but `Microsoft.SemanticKernel.Connectors.Ollama` is at 1.68.0-alpha. These should be kept in sync to avoid runtime compatibility issues.
-
-**Decision:** Update Connectors.Ollama to match core SK version (1.71.0).
-
-**Impact:** Fixes dependency skew. ~30 minutes.
-
-### Duplicate ServiceDiscoveryUtilities Class
-
-Two classes with the same name exist in different namespaces:
-- `AspireApp.Web.ServiceDiscoveryUtilities` (root namespace)
-- `AspireApp.Web.Components.Pages.ServiceDiscoveryUtilities` (Pages namespace)
-
-They have different method signatures and behavior. `HomeConfigurations` uses Pages version, `AiInfoStateService` uses root version. Maintenance hazard.
-
-**Decision:** Consolidate into single class in shared namespace. Verify both call sites work correctly after merge.
-
-**Impact:** Reduces confusion. ~1-2 hours.
-
-### OllamaWarmupService Creates Raw HttpClient
-
-Line 88 creates `new HttpClient()` instead of using `IHttpClientFactory` from DI. This bypasses resilience policies and proper lifecycle management.
-
-**Decision:** Inject `IHttpClientFactory` into OllamaWarmupService constructor and use it to create HttpClient.
-
-**Impact:** Follows .NET guidance. ~30 minutes.
-
-### Console.WriteLine Used Extensively
-
-Both `Chat.razor.cs` (35+ instances) and other services use `Console.WriteLine` for debug output instead of `ILogger<T>`. This bypasses structured logging and won't appear in Aspire telemetry.
-
-**Decision:** Replace all `Console.WriteLine` with injected `ILogger<T>`. Scope to high-impact files (Chat, FileUploadController) initially.
-
-**Impact:** Improves observability. Medium-term cleanup.
-
-### ApiService /health Endpoint Only Mapped in Development
-
-`ServiceDefaults.MapDefaultEndpoints()` line 115 has `if (app.Environment.IsDevelopment())`. Health endpoints won't exist in production. AppHost registers `WithHttpHealthCheck("/health")` for apiservice, creating a mismatch.
-
-**Decision:** Either map `/health` unconditionally or adjust AppHost expectations. For now, document as dev-only during Aspire runs.
-
-**Impact:** Fixes health check for production deployments. ~1 hour.
-
-### Redundant IConfiguration Registration
-
-`Program.cs` line 53: `builder.Services.AddSingleton<IConfiguration>(builder.Configuration)` is unnecessary. `IConfiguration` is already registered by the host builder.
-
-**Decision:** Remove redundant registration.
-
-**Impact:** Cleanup. ~5 minutes.
-
----
-
-## Python Services & Neo4j Deep Analysis — Jarvis (Python/Data) — 2026-02-21
-
-**Scope:** Python service architecture, API endpoints, contract alignment, Neo4j schema validation
-
-### CRITICAL: ~10 Missing DatabaseService Methods
-
-The routers call methods that don't exist on the current `DatabaseService` class:
-- `get_document()`, `get_unprocessed_documents()`, `get_documents_by_status()`
-- `get_processed_document()`, `save_processed_document()`
-- `get_statistics()`, `get_active_services()`, `get_file_document_sync_status()`, `force_sync_files_and_documents()`
-
-These cause `AttributeError` at runtime on most document, processing, and health check endpoints.
-
-**Decision:** Implement missing methods as thin wrappers around the current `get_file_by_id()` / `get_unprocessed_files()` API, or rewrite routers to call existing methods directly. Option (b) is cleaner and aligns with "minimal Python footprint" goal.
-
-**Implemented by Jarvis (2025-11-02):** Added 9 backward-compatibility wrapper methods to `DatabaseService`. Wrapper methods delegate to existing file-based methods + model conversion. Preserves router API contract unchanged; reuses proven internal methods; consistent with existing pattern. Commit: (from inbox decision).
-
-**Impact:** Unblocks processing pipeline. ~1 day effort → complete.
-
-### CRITICAL: save_document_page() Signature Mismatch
-
-`processing.py` line 75 calls `db.save_document_page(page_record)` passing a DocumentPage object, but the actual signature is `save_document_page(self, file_id, page_number, content, metadata, neo4j_node_id)` expecting individual arguments.
-
-**Decision:** Update call to pass individual arguments: `db.save_document_page(file_id, page_number, content, metadata, node_id)`.
-
-**Implemented by Jarvis (2025-11-02):** Fixed method invocation in `processing.py`. Commit `e9d90ea`. P0 Item 2 complete.
-
-**Impact:** Fixes document processing crash. ~1 hour → complete.
-
-### HIGH: Status Casing Mismatch ("Uploaded" vs "uploaded")
-
-C# FileUploadController writes `"Uploaded"` (capital U) but Python queries for `"uploaded"` (lowercase). Files uploaded via Web UI will never be found by Python.
-
-**Decision:** Change C# to write lowercase `"uploaded"` to match Python expectations (also matches other status values: processing, processed, error).
-
-**Implemented by Jeff (2025-11-02):** Normalized FileUploadController.cs line 123 `"Uploaded"` → `"uploaded"`. Commit `62ee545`. P0 Item 4 complete.
-
-**Impact:** Enables file discovery. ~30 minutes → complete.
-
-### HIGH: FK Column Name Mismatch on document_pages
-
-| Side | Column Name |
-|------|-------------|
-| **Python** (CREATE TABLE) | `file_id` |
-| **C#** (EF Core [Column] attribute) | `document_id` |
-
-Whichever service creates the table first determines the actual column name. The other will fail or behave incorrectly.
-
-**Decision:** Decide on canonical name (recommend `file_id` for consistency with foreign key semantics). Update C# [Column] attribute to match Python CREATE TABLE statement. Verify both sides agree before cold-start.
-
-**Implemented by Jeff & Jarvis (2025-11-02):** Aligned to canonical `file_id`. C# [Column] attribute updated; Python schema unchanged. Commits: Jeff `6e5b34b`, Jarvis `77db074`. P0 Item 2 complete.
-
-**Impact:** Fixes data integrity risk. ~2 hours → complete.
-
-### HIGH: Legacy C# Entities Reference Non-Existent Tables
-
-`DocumentEntities.cs` has `Document` mapped to `documents` table and `ProcessedDocument` mapped to `processed_documents` table. Neither table exists in Python schema. This dead code could cause confusion or conflict during migrations.
-
-**Decision:** Remove deprecated entities after verifying no remaining code references them.
-
-**Impact:** Reduces confusion. ~1-2 hours.
-
-### MEDIUM: requirements.txt Has No Version Pinning
-
-All dependencies are unpinned (`fastapi`, `uvicorn`, `neo4j`, `docling-core`, etc.). Builds are non-reproducible. `docling` especially is heavy; upgrades could break processing pipeline.
-
-**Decision:** Pin all dependencies with version constraints. Use `pip freeze` to generate reproducible requirements. Example:
-```
-fastapi==0.104.1
-uvicorn==0.24.0
-neo4j==5.14.0
-
-## P0: Upload Path Normalization & Python Footprint Minimization — Bob, Jarvis, Jeff, Buster — 2026-03-20
-
-### BLOCKING: Upload Path Normalization
-
-**Problem:** DoclingService path construction used wrong base (`/app/data/uploads` instead of `/app/data`) and wrong field (`file_path` directory instead of `file_name` filename). Result: guaranteed `FileNotFoundError`.
-
-**Decision:** Container-relative path resolution rule: `{DATA_PATH}/{file_name}` where `DATA_PATH=/app/data`. Remove `self.uploads_path` concept entirely.
-
-**Implemented by Jarvis:** Path resolver in `DoclingService.process_document()` now correctly constructs `data_mount / document.filename`. Supports both container-style and Windows-style database values.
-
-**Validation:** `test_p0_contract_audit.py` assertions converted from `expectedFailure` to live regression coverage.
-
-**Impact:** Unblocks Gate B1. Files uploaded via C# now discoverable and processable.
-
-### Python Endpoint Surface Rationalization
-
-**Decision:** Removed 7 dead endpoints:
-- `GET /documents/health/concurrent-access` (no-op pool stats)
-- `GET /documents/health/schema-sync` (always "healthy")
-- `POST /documents/admin/force-sync` (dead endpoint)
-- `GET /documents/stats/performance` (unused dashboard stats)
-- `GET /documents/health/database` (redundant with `/health`)
-- `GET /processing/status/{document_id}` (duplicate of `/documents/{document_id}/status`)
-- `GET /processing/processed-documents` (reimplements `/documents/status/completed`)
-
-**Retained (13 core + health):** Upload/process/retrieve lifecycle endpoints plus search and context retrieval.
-
-**Implemented by Jarvis & Jeff:** Endpoints removed; routers updated to canonical schema.
-
-**Impact:** Smaller attack surface, clearer contract documentation.
-
-### Python DatabaseService Footprint Minimization
-
-**Decision:** Removed 5 dead methods (only used by deleted endpoints):
-- `get_statistics()`, `get_active_services()`, `get_file_document_sync_status()`, `force_sync_files_and_documents()`, `save_document()`
-
-**Retained:** 8 core pipeline methods + 7 legacy compatibility wrappers (justified: router rewrite is P2, not P0).
-
-**Implemented by Jeff:** Sync shims and retired-schema support artifacts removed. Routers now project directly from canonical `files` and `document_pages` tables.
-
-**Impact:** Footprint minimized; compatibility layer maintained for smooth migration.
-
-### Cross-Service Contract Documentation
-
-**Deliverable:** `docs/CROSS_SERVICE_CONTRACT.md` updated with:
-1. Shared DB schema (files, document_pages) — canonical column names, types, constraints
-2. Status lifecycle: `uploaded` → `processing` → `processed` | `error`
-3. Path resolution rule: `file_path` (host) + `file_name` (container)
-4. Volume mounts: host `./data` → `/app/data` in both containers
-5. Retained API surface (16 endpoints)
-6. Ownership: C# owns upload/insert, Python owns processing/status
-
-**Impact:** Single source of truth for contract; reduces cross-service bugs.
-
-### QA Gating
-
-**Buster Review Phases:**
-1. Initial: Rejected due to incomplete test gate + contract misalignment
-2. Post-Bob revision: Approved Upload Path Normalization; footprint remains open
-3. Post-Jeff cleanup: Approved Python Footprint Minimization
-
-**Final Status:** Both P0 items approved; validation gates live; ready for production deployment.
-
----
-
-## Decision Summary (2026-03-20 Merge)
-
-**Inbox files merged and deleted:**
-- `bob-python-footprint-p0.md` → merged to decisions
-- `jarvis-python-contract-trim.md` → merged to decisions
-- `buster-p0-qa-gate.md` → merged to decisions (context only)
-- `buster-p0-footprint-gate.md` → merged to decisions (archived in log)
-- `buster-p0-python-footprint-approval.md` → merged to decisions
-- `jeff-python-footprint-minimization.md` → merged to decisions
-
-**Deduplication:** No exact duplicates found. Decisions form coherent audit trail from initial blocker → implementation → validation → approval.
-
-**Cross-agent propagation:** Updates appended to Bob, Jarvis, Jeff, Buster history.md files.
-docling-core==1.2.0
-```
-
-**Impact:** Enables reproducible builds. ~1 hour.
-
-### MEDIUM: Neo4j Operations Not Batched
-
-Pages and relationships are created one-by-one in loops instead of batched with `UNWIND`. This is slow at scale.
-
-**Decision:** Refactor page and relationship creation to use batch `UNWIND` queries. Example:
-```cypher
-UNWIND $pages as page
-CREATE (p:Page {id: page.id, document_id: page.document_id, ...})
-```
-
-**Impact:** Improves processing performance. ~4 hours.
-
-### MEDIUM: No Full-Text or Vector Index
-
-Neo4j search uses string `CONTAINS` (very slow at scale). Vector index is commented out in neo4j.conf. GDS and APOC plugins installed but unused.
-
-**Decision:** Create full-text index for text search. Enable vector index for semantic search once embeddings are added. Example:
-```cypher
-CREATE FULLTEXT INDEX ft_page_content FOR (p:Page) ON EACH [p.content]
-```
-
-**Impact:** Enables scalable search. ~2 days for vector integration.
-
-### LOW: LightRAG Container Has Zero Python Integration
-
-LightRAG is wired in AppHost as separate container with Ollama connection and Neo4j access. **No Python code calls LightRAG APIs.** Web frontend waits for it but doesn't use it. Completely standalone.
-
-**Decision:** Clarify LightRAG role: Is it replacing the custom Python RAG pipeline or supplementing it? Document decision and either (a) wire Python endpoints to call LightRAG, or (b) remove from AppHost/startup until integration code ready.
-
-**Impact:** Clarifies architecture. Depends on product decision.
-
----
-
-## P0 Completion & Roadmap Update — Bob (Lead/Architect) — 2026-03-20
-
-**Scope:** Mark P0 completions in roadmap; close out Upload Path Normalization and Python Footprint Minimization
-
-### Roadmap Status: P0 Items Complete
-
-Two P0 efforts have been successfully completed and approved:
-
-1. **Upload Path Normalization (P0)** ✅ — Files uploaded via C# Web UI are now discoverable and processable by Python services
-2. **Python Footprint Minimization (P0)** ✅ — API surface rationalized, dead endpoints removed, DatabaseService methods cleaned up
-
-**Impact:** Clears milestone Gates A, B1, B2, E, G. Enables P1 (Processing Pipeline Stabilization) to proceed without path/schema concerns.
-
-**Decision:** Record P0 completions in `roadmap/Tasks.md`. Move Upload Path Normalization and Python Footprint Minimization items into Completed Work section. Update milestone gates table. Active blockers (Gates B, F, C, D) remain pending downstream P1/P2 work.
-
-**Metadata Update:** Last Updated corrected to 2026-03-20; Active Branch updated to `task/p0-python-tasks` to reflect current working baseline.
-
----
-
----
-
-## Quality Audit — Buster (QA) — 2026-02-21
-
-**Scope:** Automated test inventory, CI/CD health, code quality patterns
-
-### CRITICAL: Zero Automated Tests
-
-The solution has no test projects and no automated test suite:
-- **C#:** 0 test projects (no xUnit/NUnit/MSTest)
-- **Python:** 6 "test" files, but NONE are actual tests. All are manual diagnostic scripts with no assertions, no pytest runner, no conftest.py, no pytest.ini.
-
-The files `test_all_builds.py`, `test_database_schema.py`, `test_services.py`, and `test_concurrent_access.py` are utility/benchmark scripts, not pytest-integrated tests.
-
-**Decision:** Establish test infrastructure before closing schema migration:
-1. Create `AspireApp.UnitTests.csproj` (xUnit)
-2. Add `pytest` to requirements.txt
-3. Create `conftest.py` and `pytest.ini`
-4. Create integration test suites per Buster's Phase 2-3 roadmap
-
-**Impact:** Enables safe refactoring of P0/P1 fixes. Blocks PR merge until CI passes.
-
-### CRITICAL: CI/CD Pipeline is Non-Functional
-
-`squad-ci.yml` is placeholder: `echo "No build commands configured"`. No build verification, no tests run, PRs merge unchecked.
-
-**Decision:** Update CI workflow to:
-1. Run `dotnet build` (with Aspire stopped to avoid file locks)
-2. Run `dotnet test` once test projects exist
-3. Run `pytest` on Python services once test suite created
-4. Block PR merge until all checks pass
-
-**Impact:** Prevents regression. Foundation work.
-
-### HIGH RISK: Logging Uses Console.WriteLine
-
-7+ files use `Console.WriteLine` instead of `ILogger<T>`:
-- `Chat.razor.cs` (35+ instances)
-- `Program.cs`, `HomeConfigurations.cs`, `ServiceDiscoveryUtilities.cs`, `AiInfoStateService.cs`, `SpeechService.cs`
-
-This bypasses structured logging and OpenTelemetry integration. Debug output won't appear in Aspire dashboard logs.
-
-**Decision:** Replace with `ILogger<T>`. Inject logger into services/components. Prioritize high-impact files (Chat, Controllers).
-
-**Impact:** Improves observability. Medium-term refactoring.
-
-### HIGH RISK: No Cross-Service Contract Tests
-
-C#↔Python communication has no validation tests. If C# changes field names or types, Python models silently diverge. This is a primary vector for runtime failures.
-
-**Decision:** Create contract test suite that verifies:
-1. C# records serialize to JSON matching Python Pydantic model field names
-2. Python models deserialize C# JSON correctly
-3. Enum values and status strings match
-4. DateTime formats are compatible
-
-Run these tests in CI on every build.
-
-**Impact:** Prevents contract drift. ~1-2 days effort.
-
-### MEDIUM: Broad catch(Exception) Everywhere
-
-27+ catch(Exception) blocks across C# and Python swallow errors or re-expose generically. Error context is lost, making debugging hard.
-
-**Decision:** Prioritize specific exception catches:
-- Catch `FileNotFoundException`, `InvalidOperationException` individually
-- Log with context (document ID, operation)
-- Re-throw with context or return structured error response
-
-**Impact:** Improves debuggability. Medium-term refactoring.
-
-### MEDIUM: Python Dependencies Unpinned
-
-`requirements.txt` has no version pins. Builds are non-reproducible. Docling is especially volatile (heavy ML dependencies).
-
-**Decision:** Pin all versions. Use `pip freeze` to generate reproducible requirements.
-
-**Impact:** Enables reproducible builds. ~1 hour.
-
-### Test Coverage Gap Matrix Priority
-
-| Feature | Risk | Recommended Test Type |
-|---------|------|----------------------|
-| Chat feature | 🔴 HIGH | Unit (service logic) + Integration (E2E with Ollama mock) |
-| File Upload | 🔴 HIGH | Unit (validation) + Integration (controller → storage) |
-| Processing pipeline | 🔴 HIGH | Integration (Python DatabaseService → Neo4j) |
-| Cross-service contracts | 🔴 HIGH | Contract tests (JSON serialization) |
-| Python routes | 🔴 HIGH | Unit (TestClient) + mocked dependencies |
-| Neo4j queries | Medium | Unit (mocked driver) + integration (real Neo4j) |
-
----
-
-## Instructions Consolidation — Bob (Lead/Architect) — 2026-02-27
-
-**Scope:** Merge project-specific context with Squad boilerplate into unified root instructions file
-
-### Consolidate copilot-instructions.md
-
-`.github/copilot-instructions.md` was replaced with 47-line Squad boilerplate, losing all project-specific context (architecture overview, day-one setup, troubleshooting, instruction lookup, repo map). Consolidated both versions into a single 167-line file that:
-
-1. **Opens with team personas** — Bob, Jeff, Jarvis, Buster described as domain owners with distinct voices
-2. **Restores operational context** — Quick Overview, Day-One Checklist, Build/Run/Test, Validation Before PR, Troubleshooting Cheatsheet, Repo Map
-3. **Retains Squad conventions** — team context, capability self-check, branch naming, PR guidelines, decision inbox
-4. **Updates all references** — .NET 10 SDK (from global.json), all 15 instruction files, all 12 prompt files
-
-**Principles:** Personas first (set ownership/tone), reference not replicate (keep root file scannable), correct versions (synced with project reality), unified voice.
-
-**Impact:** All squad members read updated file for current conventions. No instruction files modified; only root consolidation.
-
----
-
-## DocumentPage FK Column Name Alignment — Jeff & Jarvis — 2025-11-02
-
-**Scope:** P0 Item 2 — Resolve FK column name mismatch on `document_pages` table
-
-### RESOLVED: DocumentPage FK Column Alignment
-
-The `document_pages` table had conflicting column names across language boundaries:
-- **Python (source of truth):** `file_id` INTEGER NOT NULL (referencing `files(id)`)
-- **C# (EF Core):** `[Column("document_id")]` on `FileId` property
-
-This created a data integrity risk: C# and Python would disagree on the actual column name in the database.
-
-**Decision:** Aligned to canonical `file_id` (Python-defined, semantically correct).
-
-**Implementation:**
-- **Jeff (C#):** Updated `DocumentEntities.cs` `[Column("document_id")]` → `[Column("file_id")]`. Updated `UploadDbContext.cs` index name. Build verified clean. Commit: 6e5b34b.
-- **Jarvis (Python):** Updated `DocumentPage` Pydantic model, `fix_database.py`, `diagnose_database.py`, `README.md` schema docs. Commit: 77db074.
-
-**Impact:** Fixed schema alignment. P0 Item 2 closed. No more C#↔Python column name conflicts on `document_pages`.
-
----
 
 ## Dashboard Playwright Testing — Jeff, Buster, Bob — 2026-03-21
 
@@ -565,3 +82,93 @@ Failed files rows must be retry-eligible for the Python processing pipeline. The
 **Verification Status:** All regression tests passed. Contract audit passed. Database schema validated.
 
 ---
+
+---
+
+## Decision: Roadmap Status Tracking & Challenge Log
+
+**Date:** 2026-03-25  
+**By:** Bob (Lead/Architect)  
+**Triggered by:** User directive via Copilot  
+
+### What Changed
+Updated `roadmap/Tasks.md` to enforce status tracking discipline and surface emerging challenges:
+
+1. **Maintainer Reminder** — Added blockquote alert at top reminding team to update roadmap during implementation  
+2. **Implementation Challenges & Revisit Items** — New section tracking:
+   - Infrastructure risks (volume mount validation)
+   - Architectural unknowns (LightRAG story)
+   - Technical debt signals (config propagation, sparse tests)
+   - Performance concerns (Neo4j batch write profiling)
+
+### Why This Matters
+- **Information Loss Risk**: Without active tracking, progress gets lost between sessions  
+- **Visibility**: Challenges surface early, preventing late-stage surprises  
+- **Accountability**: Explicit reminder in the document forces intentional updates, not one-off checkins  
+
+### Process Rule
+From now on: roadmap edits should happen **during or immediately after** task completion, not retroactively. The reminder is the nudge.
+
+### Challenges Logged
+Five initial challenges captured:
+- Gate B may fail silently (volume mount bugs)
+- LightRAG integration surface unclear
+- Weak environment variable testing
+- Test coverage gaps
+- Neo4j write performance not yet profiled
+
+**Action**: Scribe merges this decision into `.squad/decisions.md` after approval.
+
+
+---
+
+### 2026-03-25T14:07:58Z: User directive
+**By:** Eric VanArtsdalen (via Copilot)
+**What:** Keep `roadmap/Tasks.md` updated as work progresses so status does not get lost, and track challenges or revisit-later items that may become important in future implementation.
+**Why:** User request — captured for team memory
+
+
+
+---
+
+## Decision: Roadmap Status Tracking & Challenge Log
+
+**Date:** 2026-03-25  
+**By:** Bob (Lead/Architect)  
+**Triggered by:** User directive via Copilot  
+
+### What Changed
+Updated oadmap/Tasks.md to enforce status tracking discipline and surface emerging challenges:
+
+1. **Maintainer Reminder** — Added blockquote alert at top reminding team to update roadmap during implementation  
+2. **Implementation Challenges & Revisit Items** — New section tracking:
+   - Infrastructure risks (volume mount validation)
+   - Architectural unknowns (LightRAG story)
+   - Technical debt signals (config propagation, sparse tests)
+   - Performance concerns (Neo4j batch write profiling)
+
+### Why This Matters
+- **Information Loss Risk**: Without active tracking, progress gets lost between sessions  
+- **Visibility**: Challenges surface early, preventing late-stage surprises  
+- **Accountability**: Explicit reminder in the document forces intentional updates, not one-off checkins  
+
+### Process Rule
+From now on: roadmap edits should happen **during or immediately after** task completion, not retroactively. The reminder is the nudge.
+
+### Challenges Logged
+Five initial challenges captured:
+- Gate B may fail silently (volume mount bugs)
+- LightRAG integration surface unclear
+- Weak environment variable testing
+- Test coverage gaps
+- Neo4j write performance not yet profiled
+
+**Action**: Scribe merges this decision into .squad/decisions.md after approval.
+
+---
+
+## User Directive — Roadmap Maintenance — 2026-03-25
+
+**By:** Eric VanArtsdalen (via Copilot)  
+**What:** Keep oadmap/Tasks.md updated as work progresses so status does not get lost, and track challenges or revisit-later items that may become important in future implementation.  
+**Why:** User request — captured for team memory

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -532,3 +532,36 @@ This created a data integrity risk: C# and Python would disagree on the actual c
 - **All:** The `TestFixture.cs` token/URL capture infrastructure is confirmed sound — only the assertion strategy needed fixing.
 
 
+
+---
+
+## Processing Pipeline Retry & Lifecycle Canonicalization — Jarvis & Buster — 2026-03-25
+
+**Scope:** P1 Item 1 — Stabilize canonical uploaded to processing to processed/error lifecycle; prevent duplicate processing
+
+### Processing Retry Reset (Jarvis Decision)
+
+When a file enters processing, the Python service now resets stale processing artifacts in the same lifecycle step. That includes clearing completion/error fields, clearing docling/Neo4j output columns, and deleting any existing document_pages rows for the file.
+
+**Rationale:** Retries were not safe if a previous attempt partially persisted output before failing. The canonical schema enforces UNIQUE(file_id, page_number), so leaving old page rows behind turns recovery attempts into duplicate-write failures instead of a clean retry.
+
+**Impact:**
+- Keeps lifecycle transitions canonical: uploaded to processing to processed / error
+- Allows failed rows to re-enter batch processing without manual cleanup
+- Preserves processed rows unless an explicit new processing attempt is started
+
+### Processing Retries Stay Canonical (Buster Decision)
+
+Failed files rows must be retry-eligible for the Python processing pipeline. The next processing transition must clear stale failure markers before work resumes.
+
+**QA Expectations:**
+- Canonical lifecycle stays uploaded to processing to processed / error
+- Failed rows remain discoverable by list_unprocessed_documents()
+- Retrying a failed row clears stale processing_error and processing_completed_at
+- process_document_task() is covered for both success and failure status updates
+
+**Rationale:** Without this rule, batch reprocessing silently skips failures or reports contradictory state (processing with an old completion timestamp/error). That regression passes happy-path tests and still burns operators.
+
+**Verification Status:** All regression tests passed. Contract audit passed. Database schema validated.
+
+---

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,9 +1,10 @@
 ---
-updated_at: 2026-02-21T23:33:00Z
-focus_area: Codebase analysis and strategic planning
-active_issues: []
+updated_at: 2026-03-25T13:28:24Z
+focus_area: Processing pipeline stabilization (P1)
+active_issues:
+  - roadmap/Tasks.md :: Processing Pipeline Stabilization (P1)
 ---
 
 # What We're Focused On
 
-Full codebase review and analysis. Team is auditing architecture, .NET services, Python services, and test coverage to build an advised strategic plan.
+Stabilizing the Python document processing pipeline so uploaded `files` rows move cleanly through Docling into `document_pages`, with canonical status transitions, consistent timestamps/error persistence, and retry handling for failed records.

--- a/roadmap/Tasks.md
+++ b/roadmap/Tasks.md
@@ -2,10 +2,11 @@
 
 Working task breakdown for the [Plan](../plan.md). Tracks what's been accomplished and what remains.
 
+> **⚠️ Maintainer Reminder:** This roadmap should be updated as work progresses to keep status current and prevent information loss. Check this file regularly during implementation and mark items complete/blocked as they change.
+
 Note: This will be a living document.
 
 **Last Updated:** 2026-03-25
-**Active Branch:** `task/p0-python-tasks`
 
 ---
 
@@ -50,7 +51,7 @@ Note: This will be a living document.
 
 ## Active Tasks
 
-### Processing Pipeline Stabilization (P1)
+### Processing Pipeline Stabilization (P1) (Done) ✅
 
 - [x] Process uploaded records through Docling and persist page content in `document_pages`
 - [x] Persist processing timestamps and error details consistently
@@ -173,3 +174,15 @@ Note: This will be a living document.
 - [ ] Trigger Python processing ? verify row is selected even if status arrives as `Uploaded`
 - [ ] Verify processing reads file from mapped volume and writes `document_pages` rows
 - [ ] Verify status transitions end at `processed` (or `error` with `processing_error` populated)
+
+---
+
+## Implementation Challenges & Revisit Items
+
+Track issues, blockers, and future follow-up items that emerge during implementation. Revisit periodically to ensure nothing falls through the cracks.
+
+- **[Gate B Status]** Processing pipeline may fail silently if volume mounts are misconfigured; consider health check validation for file access before triggering processing
+- **[LightRAG Integration]** Need to confirm LightRAG containerization story (Docker image, Neo4j connectivity, ingestion API shape) before finalizing Docling → LightRAG handoff
+- **[AI Model Config]** Config key mismatch (`AI-Model` vs service-specific reads) indicates weak testing of environment propagation; consider Aspire contract tests
+- **[Testing Strategy]** Current test matrix is sparse; prioritize upload-to-processing happy path before expanding coverage (risk of regressions is moderate)
+- **[Performance Baseline]** Neo4j batch writes not yet profiled; if processing is slow, start here before adding vector indexing

--- a/roadmap/Tasks.md
+++ b/roadmap/Tasks.md
@@ -4,7 +4,7 @@ Working task breakdown for the [Plan](../plan.md). Tracks what's been accomplish
 
 Note: This will be a living document.
 
-**Last Updated:** 2026-03-20
+**Last Updated:** 2026-03-25
 **Active Branch:** `task/p0-python-tasks`
 
 ---
@@ -52,10 +52,10 @@ Note: This will be a living document.
 
 ### Processing Pipeline Stabilization (P1)
 
-- [ ] Process uploaded records through Docling and persist page content in `document_pages`
-- [ ] Persist processing timestamps and error details consistently
-- [ ] Add retry behavior for failed processing records
-- [ ] Ensure processing status transitions use canonical values (`uploaded` ? `processing` ? `processed` / `error`)
+- [x] Process uploaded records through Docling and persist page content in `document_pages`
+- [x] Persist processing timestamps and error details consistently
+- [x] Add retry behavior for failed processing records
+- [x] Ensure processing status transitions use canonical values (`uploaded` ? `processing` ? `processed` / `error`)
 
 **Files:**
 - `src/AspireApp.PythonServices/app/routers/processing.py` — ensure processing consumes resolved full file path; use canonical status transitions

--- a/src/AspireApp.PythonServices/app/routers/processing.py
+++ b/src/AspireApp.PythonServices/app/routers/processing.py
@@ -27,14 +27,14 @@ async def process_document_task(
     """Background task to process a document"""
     try:
         logger.info(f"Starting processing for document {document_id}")
-        
-        # Update status to processing
-        db.update_file_status(document_id, "processing")
-        
+
         # Get document
         document = db.get_document_by_id(document_id)
         if not document:
             raise Exception("Document not found")
+
+        # Mark the attempt active after confirming the record still exists.
+        db.update_file_status(document_id, "processing")
 
         resolved_file_path = db.resolve_upload_path(document)
         
@@ -106,6 +106,9 @@ async def process_document(
         # Check if already processed
         if document.processing_status == "processed":
             raise HTTPException(status_code=400, detail="Document already processed")
+
+        if document.processing_status == "processing":
+            raise HTTPException(status_code=409, detail="Document is already processing")
         
         # Get the appropriate docling service
         docling = get_docling_service()
@@ -134,12 +137,12 @@ async def process_all_documents(
     db: DatabaseService = Depends(get_database_service),
     neo4j: Neo4jService = Depends(get_neo4j_service)
 ):
-    """Start processing all unprocessed documents"""
+    """Start processing all uploaded or retryable documents."""
     try:
         unprocessed_docs = db.list_unprocessed_documents()
         
         if not unprocessed_docs:
-            return {"message": "No unprocessed documents found"}
+            return {"message": "No uploaded or failed documents are ready for processing"}
         
         # Get the appropriate docling service
         docling = get_docling_service()

--- a/src/AspireApp.PythonServices/app/services/database_service.py
+++ b/src/AspireApp.PythonServices/app/services/database_service.py
@@ -346,7 +346,7 @@ class DatabaseService:
             raise
 
     def get_unprocessed_files(self) -> List[Dict[str, Any]]:
-        """Get all files that need processing (status='uploaded')"""
+        """Get all files currently eligible for processing or retry."""
         try:
             with self._pool.get_connection() as conn:
                 cursor = conn.cursor()
@@ -356,12 +356,12 @@ class DatabaseService:
                            processing_started_at, processing_completed_at, processing_error,
                            docling_document_path, total_pages, neo4j_document_node_id,
                            source_type, source_url
-                    FROM files 
-                    WHERE LOWER(status) = 'uploaded'
+                    FROM files
+                    WHERE LOWER(status) IN ('uploaded', 'error')
                     ORDER BY uploaded_at ASC
                 """)
                 rows = cursor.fetchall()
-                logger.info(f"Found {len(rows)} unprocessed files")
+                logger.info(f"Found {len(rows)} files ready for processing")
                 return [self._row_to_file_dict(row) for row in rows]
         except Exception as e:
             logger.error(f"Error fetching unprocessed files: {e}")
@@ -623,11 +623,17 @@ class DatabaseService:
                 
                 if normalized_status == 'processing':
                     cursor.execute("""
-                        UPDATE files 
-                        SET status = ?, 
-                            processing_started_at = CURRENT_TIMESTAMP
+                        UPDATE files
+                        SET status = ?,
+                            processing_started_at = CURRENT_TIMESTAMP,
+                            processing_completed_at = NULL,
+                            processing_error = NULL,
+                            docling_document_path = NULL,
+                            total_pages = NULL,
+                            neo4j_document_node_id = NULL
                         WHERE id = ?
                     """, (normalized_status, file_id))
+                    cursor.execute("DELETE FROM document_pages WHERE file_id = ?", (file_id,))
                 elif normalized_status == 'processed':
                     cursor.execute("""
                         UPDATE files 
@@ -644,6 +650,19 @@ class DatabaseService:
                             processing_error = ?
                         WHERE id = ?
                     """, (normalized_status, error, file_id))
+                elif normalized_status == 'uploaded':
+                    cursor.execute("""
+                        UPDATE files
+                        SET status = ?,
+                            processing_started_at = NULL,
+                            processing_completed_at = NULL,
+                            processing_error = NULL,
+                            docling_document_path = NULL,
+                            total_pages = NULL,
+                            neo4j_document_node_id = NULL
+                        WHERE id = ?
+                    """, (normalized_status, file_id))
+                    cursor.execute("DELETE FROM document_pages WHERE file_id = ?", (file_id,))
                 else:
                     cursor.execute("""
                         UPDATE files SET status = ? WHERE id = ?

--- a/src/AspireApp.PythonServices/tests/test_p0_contract_audit.py
+++ b/src/AspireApp.PythonServices/tests/test_p0_contract_audit.py
@@ -176,13 +176,21 @@ class DatabaseContractAuditTests(unittest.TestCase):
                     document = service.get_document_by_id(file_id)
                     unprocessed = service.list_unprocessed_documents()
 
-                    service.update_file_status(file_id, "processed")
+                    service.update_file_status(file_id, "processing")
                     service.update_file_processing_results(
                         file_id=file_id,
                         docling_path="/app/data/processed/documents/1/document.json",
                         total_pages=3,
                     )
+                    service.save_document_page(
+                        file_id=file_id,
+                        page_number=1,
+                        content="Persisted page content",
+                        metadata={"page_number": 1},
+                    )
+                    service.update_file_status(file_id, "processed")
                     status = service.get_processing_status(file_id)
+                    pages = service.get_document_pages(file_id)
                 finally:
                     _close_database_pools(DatabaseService)
                     if previous_db_path is None:
@@ -202,6 +210,121 @@ class DatabaseContractAuditTests(unittest.TestCase):
                 self.assertEqual(1, len(unprocessed))
                 self.assertEqual("processed", status.status)
                 self.assertEqual(3, status.total_pages)
+                self.assertEqual(1, len(pages))
+                self.assertEqual("Persisted page content", pages[0]["content"])
+
+    def test_unprocessed_documents_include_retryable_error_rows(self):
+        with _patched_dependencies():
+            from app.services.database_service import DatabaseService
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                db_path = Path(temp_dir) / "data-resources.db"
+                previous_db_path = os.environ.get("ASPIRE_DB_PATH")
+                os.environ["ASPIRE_DB_PATH"] = str(db_path)
+                try:
+                    _close_database_pools(DatabaseService)
+                    service = DatabaseService()
+
+                    uploaded_id = service.create_file_record(
+                        file_name="uploaded.pdf",
+                        original_file_name="uploaded.pdf",
+                        file_path=str(Path(temp_dir) / "uploads"),
+                        status="uploaded",
+                    )
+                    failed_id = service.create_file_record(
+                        file_name="failed.pdf",
+                        original_file_name="failed.pdf",
+                        file_path=str(Path(temp_dir) / "uploads"),
+                        status="uploaded",
+                    )
+                    processing_id = service.create_file_record(
+                        file_name="processing.pdf",
+                        original_file_name="processing.pdf",
+                        file_path=str(Path(temp_dir) / "uploads"),
+                        status="uploaded",
+                    )
+                    processed_id = service.create_file_record(
+                        file_name="processed.pdf",
+                        original_file_name="processed.pdf",
+                        file_path=str(Path(temp_dir) / "uploads"),
+                        status="uploaded",
+                    )
+
+                    service.update_file_status(failed_id, "processing")
+                    service.update_file_status(failed_id, "error", "boom")
+                    service.update_file_status(processing_id, "processing")
+                    service.update_file_status(processed_id, "processing")
+                    service.update_file_status(processed_id, "processed")
+
+                    retryable_ids = {
+                        doc.id for doc in service.list_unprocessed_documents()
+                    }
+                finally:
+                    _close_database_pools(DatabaseService)
+                    if previous_db_path is None:
+                        os.environ.pop("ASPIRE_DB_PATH", None)
+                    else:
+                        os.environ["ASPIRE_DB_PATH"] = previous_db_path
+
+                self.assertEqual({uploaded_id, failed_id}, retryable_ids)
+
+    def test_processing_status_resets_stale_artifacts_on_retry(self):
+        with _patched_dependencies():
+            from app.services.database_service import DatabaseService
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                db_path = Path(temp_dir) / "data-resources.db"
+                previous_db_path = os.environ.get("ASPIRE_DB_PATH")
+                os.environ["ASPIRE_DB_PATH"] = str(db_path)
+                try:
+                    _close_database_pools(DatabaseService)
+                    service = DatabaseService()
+                    file_id = service.create_file_record(
+                        file_name="retry.pdf",
+                        original_file_name="retry.pdf",
+                        file_path=str(Path(temp_dir) / "uploads"),
+                        status="uploaded",
+                    )
+
+                    service.update_file_status(file_id, "processing")
+                    service.update_file_processing_results(
+                        file_id=file_id,
+                        docling_path="/app/data/processed/documents/retry/document.json",
+                        total_pages=2,
+                        neo4j_node_id="doc-node",
+                    )
+                    service.save_document_page(
+                        file_id=file_id,
+                        page_number=1,
+                        content="Old page",
+                        metadata={"attempt": 1},
+                        neo4j_node_id="page-node",
+                    )
+                    service.update_file_status(file_id, "error", "first attempt failed")
+
+                    service.update_file_status(file_id, "processing")
+
+                    record = service.get_file_by_id(file_id)
+                    status = service.get_processing_status(file_id)
+                    pages = service.get_document_pages(file_id)
+                finally:
+                    _close_database_pools(DatabaseService)
+                    if previous_db_path is None:
+                        os.environ.pop("ASPIRE_DB_PATH", None)
+                    else:
+                        os.environ["ASPIRE_DB_PATH"] = previous_db_path
+
+                self.assertEqual("processing", record["status"])
+                self.assertIsNotNone(record["processing_started_at"])
+                self.assertIsNone(record["processing_completed_at"])
+                self.assertIsNone(record["processing_error"])
+                self.assertIsNone(record["docling_document_path"])
+                self.assertIsNone(record["total_pages"])
+                self.assertIsNone(record["neo4j_document_node_id"])
+                self.assertEqual([], pages)
+                self.assertEqual("processing", status.status)
+                self.assertIsNone(status.error_message)
+                self.assertIsNone(status.completed_at)
 
 
 def _close_database_pools(database_service_type) -> None:

--- a/src/AspireApp.PythonServices/tests/test_processing_pipeline_regression.py
+++ b/src/AspireApp.PythonServices/tests/test_processing_pipeline_regression.py
@@ -1,0 +1,408 @@
+import gc
+import os
+import shutil
+import sys
+import types
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRATCH_ROOT = Path(__file__).resolve().parent / "_scratch_processing_pipeline"
+
+
+def _purge_modules(*prefixes: str) -> None:
+    for module_name in list(sys.modules):
+        if any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in prefixes
+        ):
+            sys.modules.pop(module_name, None)
+
+
+def _install_fake_pydantic() -> None:
+    module = types.ModuleType("pydantic")
+
+    class BaseModel:
+        def __init__(self, **kwargs):
+            annotations = {}
+            for cls in reversed(self.__class__.__mro__):
+                annotations.update(getattr(cls, "__annotations__", {}))
+
+            for field_name in annotations:
+                if field_name in kwargs:
+                    value = kwargs[field_name]
+                elif hasattr(self.__class__, field_name):
+                    value = getattr(self.__class__, field_name)
+                else:
+                    value = None
+                setattr(self, field_name, value)
+
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+        def dict(self):
+            return self.__dict__.copy()
+
+    module.BaseModel = BaseModel
+    sys.modules["pydantic"] = module
+
+
+def _install_fake_fastapi() -> None:
+    module = types.ModuleType("fastapi")
+
+    class APIRouter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def post(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def get(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class BackgroundTasks:
+        def add_task(self, *args, **kwargs):
+            return None
+
+    def Depends(dependency):
+        return dependency
+
+    module.APIRouter = APIRouter
+    module.HTTPException = HTTPException
+    module.Depends = Depends
+    module.BackgroundTasks = BackgroundTasks
+    sys.modules["fastapi"] = module
+
+
+def _install_processing_stubs() -> None:
+    service_factory_module = types.ModuleType("app.services.service_factory")
+    service_factory_module.get_docling_service = lambda: None
+
+    neo4j_module = types.ModuleType("app.services.neo4j_service")
+
+    class Neo4jService:
+        pass
+
+    neo4j_module.Neo4jService = Neo4jService
+
+    sys.modules["app.services.service_factory"] = service_factory_module
+    sys.modules["app.services.neo4j_service"] = neo4j_module
+
+
+@contextmanager
+def _patched_database_dependencies():
+    original_modules = {"pydantic": sys.modules.get("pydantic")}
+
+    _purge_modules("app")
+    _install_fake_pydantic()
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+    try:
+        yield
+    finally:
+        sys.path = [path for path in sys.path if path != str(PROJECT_ROOT)]
+        _purge_modules("app")
+        original_module = original_modules["pydantic"]
+        if original_module is None:
+            sys.modules.pop("pydantic", None)
+        else:
+            sys.modules["pydantic"] = original_module
+
+
+@contextmanager
+def _patched_processing_dependencies():
+    original_modules = {
+        name: sys.modules.get(name)
+        for name in [
+            "pydantic",
+            "fastapi",
+            "app.services.service_factory",
+            "app.services.neo4j_service",
+        ]
+    }
+
+    _purge_modules("app", "fastapi")
+    _install_fake_pydantic()
+    _install_fake_fastapi()
+    _install_processing_stubs()
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+    try:
+        yield
+    finally:
+        sys.path = [path for path in sys.path if path != str(PROJECT_ROOT)]
+        _purge_modules("app", "fastapi")
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def _close_database_pools(database_service_type) -> None:
+    for pool in database_service_type._pools.values():
+        pool.close_all()
+    database_service_type._pools.clear()
+
+
+@contextmanager
+def _database_service_sandbox(case_name: str):
+    with _patched_database_dependencies():
+        from app.services.database_service import DatabaseService
+
+        scratch_dir = SCRATCH_ROOT / f"{case_name}_{uuid4().hex}"
+        uploads_dir = scratch_dir / "uploads"
+        uploads_dir.mkdir(parents=True, exist_ok=True)
+        db_path = scratch_dir / "data-resources.db"
+
+        previous_db_path = os.environ.get("ASPIRE_DB_PATH")
+        os.environ["ASPIRE_DB_PATH"] = str(db_path)
+
+        try:
+            _close_database_pools(DatabaseService)
+            yield DatabaseService(), uploads_dir
+        finally:
+            _close_database_pools(DatabaseService)
+            gc.collect()
+            if previous_db_path is None:
+                os.environ.pop("ASPIRE_DB_PATH", None)
+            else:
+                os.environ["ASPIRE_DB_PATH"] = previous_db_path
+            shutil.rmtree(scratch_dir, ignore_errors=True)
+            if SCRATCH_ROOT.exists() and not any(SCRATCH_ROOT.iterdir()):
+                SCRATCH_ROOT.rmdir()
+
+
+class ProcessingStatusLifecycleTests(unittest.TestCase):
+    def test_status_lifecycle_uses_canonical_values_and_tracks_timestamps(self):
+        with _database_service_sandbox("canonical_status_lifecycle") as (service, uploads_dir):
+            file_id = service.create_file_record(
+                file_name="stored-file.pdf",
+                original_file_name="original.pdf",
+                file_path=str(uploads_dir),
+                file_size=4,
+                mime_type="application/pdf",
+                status="Uploaded",
+            )
+
+            initial_status = service.get_processing_status(file_id)
+            self.assertEqual("uploaded", initial_status.status)
+            self.assertIsNone(initial_status.completed_at)
+            self.assertIsNone(initial_status.error_message)
+
+            service.update_file_status(file_id, "processing")
+            processing_status = service.get_processing_status(file_id)
+            self.assertEqual("processing", processing_status.status)
+            self.assertIsNotNone(processing_status.started_at)
+            self.assertIsNone(processing_status.completed_at)
+            self.assertIsNone(processing_status.error_message)
+
+            service.update_file_processing_results(
+                file_id=file_id,
+                docling_path="/app/data/processed/documents/1/document.json",
+                total_pages=2,
+            )
+            service.update_file_status(file_id, "processed")
+
+            processed_status = service.get_processing_status(file_id)
+            self.assertEqual("processed", processed_status.status)
+            self.assertEqual(2, processed_status.total_pages)
+            self.assertIsNotNone(processed_status.started_at)
+            self.assertIsNotNone(processed_status.completed_at)
+            self.assertIsNone(processed_status.error_message)
+
+    def test_failed_records_are_retry_eligible_and_retry_clears_stale_failure_state(self):
+        with _database_service_sandbox("retry_eligibility") as (service, uploads_dir):
+            file_id = service.create_file_record(
+                file_name="retry-file.pdf",
+                original_file_name="retry-file.pdf",
+                file_path=str(uploads_dir),
+                file_size=4,
+                mime_type="application/pdf",
+                status="uploaded",
+            )
+
+            service.update_file_status(file_id, "processing")
+            service.update_file_status(file_id, "error", "docling exploded")
+
+            failed_status = service.get_processing_status(file_id)
+            self.assertEqual("error", failed_status.status)
+            self.assertEqual("docling exploded", failed_status.error_message)
+            self.assertIsNotNone(failed_status.started_at)
+            self.assertIsNotNone(failed_status.completed_at)
+
+            retryable_ids = {document.id for document in service.list_unprocessed_documents()}
+            self.assertIn(file_id, retryable_ids)
+
+            service.update_file_status(file_id, "processing")
+            retrying_status = service.get_processing_status(file_id)
+            self.assertEqual("processing", retrying_status.status)
+            self.assertIsNotNone(retrying_status.started_at)
+            self.assertIsNone(retrying_status.completed_at)
+            self.assertIsNone(retrying_status.error_message)
+
+
+class FakeDatabase:
+    def __init__(self, document, resolved_path: Path):
+        self.document = document
+        self.resolved_path = resolved_path
+        self.status_updates = []
+        self.resolve_calls = []
+        self.processing_results = []
+        self.saved_pages = []
+
+    def update_file_status(self, file_id: int, status: str, error: str = None) -> None:
+        self.status_updates.append((file_id, status, error))
+
+    def get_document_by_id(self, document_id: int):
+        return self.document if document_id == self.document.id else None
+
+    def resolve_upload_path(self, document):
+        self.resolve_calls.append(document)
+        return self.resolved_path
+
+    def update_file_processing_results(self, **kwargs) -> None:
+        self.processing_results.append(kwargs)
+
+    def save_document_page(self, **kwargs) -> None:
+        self.saved_pages.append(kwargs)
+
+
+class FakeNeo4j:
+    def __init__(self):
+        self.document_nodes = []
+        self.page_batches = []
+        self.relationships = []
+        self.sequential_relationships = []
+
+    def create_document_node(self, document):
+        self.document_nodes.append(document)
+        return "doc-node-1"
+
+    def create_page_nodes(self, pages, doc_node_id, document_id):
+        self.page_batches.append((pages, doc_node_id, document_id))
+        return [f"page-node-{index}" for index, _ in enumerate(pages, start=1)]
+
+    def create_relationships(self, doc_node_id, page_node_ids):
+        self.relationships.append((doc_node_id, list(page_node_ids)))
+
+    def create_sequential_relationships(self, page_node_ids):
+        self.sequential_relationships.append(list(page_node_ids))
+
+
+class FakeDocling:
+    def __init__(self, processed_doc, pages, error: Exception = None):
+        self.processed_doc = processed_doc
+        self.pages = pages
+        self.error = error
+        self.calls = []
+
+    def process_document(self, document, resolved_file_path):
+        self.calls.append((document, resolved_file_path))
+        if self.error is not None:
+            raise self.error
+        return self.processed_doc, self.pages
+
+
+class ProcessDocumentTaskRegressionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_process_document_task_marks_processed_and_persists_pages(self):
+        with _patched_processing_dependencies():
+            from app.routers.processing import process_document_task
+
+            document = SimpleNamespace(id=41, filename="stored-file.pdf")
+            processed_doc = SimpleNamespace(
+                docling_document_path="/app/data/processed/documents/41/document.json",
+                total_pages=2,
+                neo4j_node_id=None,
+            )
+            pages = [
+                SimpleNamespace(page_number=1, content="Page one", metadata={"section": "intro"}),
+                SimpleNamespace(page_number=2, content="Page two", metadata={"section": "body"}),
+            ]
+            db = FakeDatabase(document=document, resolved_path=Path("C:\\app\\data\\uploads\\stored-file.pdf"))
+            docling = FakeDocling(processed_doc=processed_doc, pages=pages)
+            neo4j = FakeNeo4j()
+
+            await process_document_task(41, db, docling, neo4j)
+
+            self.assertEqual(
+                [(41, "processing", None), (41, "processed", None)],
+                db.status_updates,
+            )
+            self.assertEqual([document], db.resolve_calls)
+            self.assertEqual([(document, db.resolved_path)], docling.calls)
+            self.assertEqual(
+                [
+                    {
+                        "file_id": 41,
+                        "docling_path": processed_doc.docling_document_path,
+                        "total_pages": 2,
+                        "neo4j_node_id": "doc-node-1",
+                    }
+                ],
+                db.processing_results,
+            )
+            self.assertEqual(
+                [
+                    {
+                        "file_id": 41,
+                        "page_number": 1,
+                        "content": "Page one",
+                        "metadata": {"section": "intro"},
+                        "neo4j_node_id": "page-node-1",
+                    },
+                    {
+                        "file_id": 41,
+                        "page_number": 2,
+                        "content": "Page two",
+                        "metadata": {"section": "body"},
+                        "neo4j_node_id": "page-node-2",
+                    },
+                ],
+                db.saved_pages,
+            )
+
+    async def test_process_document_task_marks_error_when_processing_fails(self):
+        with _patched_processing_dependencies():
+            from app.routers.processing import process_document_task
+
+            document = SimpleNamespace(id=77, filename="broken-file.pdf")
+            db = FakeDatabase(document=document, resolved_path=Path("C:\\app\\data\\uploads\\broken-file.pdf"))
+            docling = FakeDocling(
+                processed_doc=None,
+                pages=[],
+                error=RuntimeError("docling exploded"),
+            )
+            neo4j = FakeNeo4j()
+
+            with self.assertRaisesRegex(RuntimeError, "docling exploded"):
+                await process_document_task(77, db, docling, neo4j)
+
+            self.assertEqual(
+                [(77, "processing", None), (77, "error", "docling exploded")],
+                db.status_updates,
+            )
+            self.assertEqual([document], db.resolve_calls)
+            self.assertEqual([(document, db.resolved_path)], docling.calls)
+            self.assertEqual([], db.processing_results)
+            self.assertEqual([], db.saved_pages)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### PR Classification
Bug fix and test coverage improvement for the Python document processing pipeline, with roadmap and documentation updates.

#### PR Summary
This PR stabilizes the Python processing pipeline by making retries safe and canonical, expands regression test coverage, and enforces better roadmap discipline.
- `database_service.py`, `processing.py`: Robust retry logic—resetting stale fields and clearing `document_pages` on reprocessing; processing now includes both "uploaded" and "error" files; duplicate processing starts are rejected.
- `test_p0_contract_audit.py`, `test_processing_pipeline_regression.py`: Added and expanded regression tests for status transitions, retry safety, and artifact resets, runnable without FastAPI/Pydantic.
- `Tasks.md`: Added a maintainer reminder and a new section for tracking implementation challenges and revisit items.
- `decisions.md`: Documented the new roadmap update discipline and canonical retry logic.
- `now.md`: Updated focus to "Processing pipeline stabilization (P1)" and set the active issue accordingly.
